### PR TITLE
Firestoreのドキュメントをミーティングごとに変更するようにした！

### DIFF
--- a/public/agenda.js
+++ b/public/agenda.js
@@ -23,8 +23,10 @@ function sendAgenda(agenda) {
 
 // Listen to sync-agenda-beta collection; code below will be run
 // when something has changed on Firestore > sync-agenda-beta
-db.collection(syncAgendaCollection).doc(meetingId).onSnapshot((doc) => {
-	const newAgenda = doc.data().agenda;
+function listenAgenda() {
+	db.collection(syncAgendaCollection).doc(meetingId).onSnapshot((doc) => {
+		const newAgenda = doc.data().agenda;
 
-	$('#agenda-out').text(newAgenda);
-});
+		$('#agenda-out').text(newAgenda);
+	});
+}

--- a/public/bgm.js
+++ b/public/bgm.js
@@ -52,50 +52,52 @@ stopButton.addEventListener("click", function () {
 	configureControlPanelDefault();
 });
 
-db.collection(syncBgmCollection).doc(meetingId) // listen to "currentTrackId"
-	.onSnapshot((doc) => {
+function listenBgm() {
+	db.collection(syncBgmCollection).doc(meetingId) // listen to "currentTrackId"
+		.onSnapshot((doc) => {
 
-		// Only for debugging
-		// console.log("Current data: ", doc.data());
+			// Only for debugging
+			// console.log("Current data: ", doc.data());
 
-		const currentTrackId = doc.data().currentTrackId;
-		const currentTime = doc.data().currentTime;
-		const isPlaying = doc.data().isPlaying;
-		const isChanged = doc.data().isChanged;
+			const currentTrackId = doc.data().currentTrackId;
+			const currentTime = doc.data().currentTime;
+			const isPlaying = doc.data().isPlaying;
+			const isChanged = doc.data().isChanged;
 
-		if (!$(".meeting-area").is(":hidden")) {
+			if (!$(".meeting-area").is(":hidden")) {
 
-			if (isChanged) {
+				if (isChanged) {
 
-				const docRef = db.collection(audioSetCollection).doc(currentTrackId);
+					const docRef = db.collection(audioSetCollection).doc(currentTrackId);
 
-				docRef.get().then((doc) => {
-					if (doc.exists) {
+					docRef.get().then((doc) => {
+						if (doc.exists) {
 
-						// Only for debugging
-						// console.log("audioSet data: ", doc.data());
+							// Only for debugging
+							// console.log("audioSet data: ", doc.data());
 
-						changeTrackTo(doc.data().uri, currentTime);
-						changeSelectorTo(doc.data().category);
-						configureControlPanelPlaying();
-					}
-				})
-			} else {
-				/*
-				 * If audio track is not changed but paused or resumed
-				 */
-				if (isPlaying) {
-					audioElm.currentTime = currentTime;
-					audioElm.play()
-					configureControlPanelPlaying();
+							changeTrackTo(doc.data().uri, currentTime);
+							changeSelectorTo(doc.data().category);
+							configureControlPanelPlaying();
+						}
+					})
 				} else {
-					audioElm.pause();
-					audioElm.currentTime = currentTime;
-					configureControlPanelPaused();
+					/*
+					 * If audio track is not changed but paused or resumed
+					 */
+					if (isPlaying) {
+						audioElm.currentTime = currentTime;
+						audioElm.play()
+						configureControlPanelPlaying();
+					} else {
+						audioElm.pause();
+						audioElm.currentTime = currentTime;
+						configureControlPanelPaused();
+					}
 				}
 			}
-		}
-	});
+		});
+}
 
 function sendBgmStatus(currentTime, isChanged, isPlaying) {
 	const category = selectorObj.value;
@@ -118,7 +120,7 @@ function sendBgmStatus(currentTime, isChanged, isPlaying) {
 					currentTrackId: currentTrackId,
 					isChanged: isChanged,
 					isPlaying: isPlaying
-				})
+				});
 			});
 		})
 		.catch((error) => {

--- a/public/index.js
+++ b/public/index.js
@@ -116,6 +116,12 @@ function initAgora() {
  * Join a channel, then create local video and audio tracks and publish them to the channel.
  */
 async function join() {
+	meetingId = generateMeetingId();
+
+	listenAgenda();
+	listenBgm();
+	// TODO: implement functionality
+	// listenTimer();
 
 	// Add an event listener to play remote tracks when remote user publishes.
 	client.on("user-published", handleUserPublished);
@@ -137,7 +143,6 @@ async function join() {
 	localTracks.videoTrack.play("local-player");
 	$("#local-player-name").text(`${options.userName} (You)`);
 
-	meetingId = generateMeetingId();
 
 	// Publish the local video and audio tracks to the channel.
 	await client.publish(Object.values(localTracks));


### PR DESCRIPTION
1. `index.js` 内で `meetingId` を生成（`options.token` から `/` を抜いただけ）
2. `bgm.js` `agenda.js` でFirestoreに各種データを送る際、`meetingId` をドキュメントIDにセット

これで複数ミーティングが開催されると勝手にBGM/アジェンダが変わる問題は解決したはず 🎉 

```js
db.collection(syncBgmCollection).doc(meetingId).set({
	currentTime: currentTime,
	currentTrackId: currentTrackId,
	isChanged: isChanged,
	isPlaying: isPlaying
});
```