### PR TITLE
fix(link to github): users now can go directly to readme.md

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -203,7 +203,7 @@
 		</a>
 
 		<!-- View Source on GitHub -->
-		<a href="https://github.com/hummingbird-jp/stat-web" target="_blank" rel="noopener noreferrer">
+		<a href="https://github.com/hummingbird-jp/stat-web#readme" target="_blank" rel="noopener noreferrer">
 			<svg id="github-icon" xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24"
 				fill="aliceblue">
 				<path


### PR DESCRIPTION
GitHubアイコンをクリックすると直接README.mdに飛ぶよう変更しました

fix #93