### PR TITLE
発言量バーの横棒が画面外に飛び出ないようにした

### DIFF
--- a/public/voice-visualizer.js
+++ b/public/voice-visualizer.js
@@ -231,14 +231,11 @@ async function getTalkDataFromFirebase() {
 	let members = [];
 	const querySnapshotUser = await dbRootRef.collection(usersCollection).get()
 	querySnapshotUser.forEach((doc) => {
-		if (doc.data().isActive) {
-
-			members.push({
-				"userName": doc.data().userName,
-				"uid": doc.data().uid,
-				"talkSum": 0
-			});
-		}
+		members.push({
+			"userName": doc.data().userName,
+			"uid": doc.data().uid,
+			"talkSum": 0
+		})
 	});
 
 	const querySnapshotTalkData = await dbRootRef.collection(talkDataCollection).orderBy("timestamp", "desc").limit(10).get()
@@ -257,8 +254,4 @@ async function getTalkDataFromFirebase() {
 	});
 
 	return members;
-}
-
-function updateTalkVisualizer() {
-
 }

--- a/public/voice-visualizer.js
+++ b/public/voice-visualizer.js
@@ -151,8 +151,7 @@ function initTalkVisualizer() {
 					for (let i = 0; i < result.length; i++) {
 						sum += result[i].talkSum;
 					}
-					const MAXWIDTH = $('#voice-visualizer-group').first().innerWidth();
-					canvas.setAttribute("width", MAXWIDTH / 500 * sum);
+					canvas.setAttribute("width", $('#voice-visualizer-group').first().innerWidth());
 					const WIDTH = canvas.width;
 					const HEIGHT = canvas.height;
 
@@ -232,11 +231,14 @@ async function getTalkDataFromFirebase() {
 	let members = [];
 	const querySnapshotUser = await dbRootRef.collection(usersCollection).get()
 	querySnapshotUser.forEach((doc) => {
-		members.push({
-			"userName": doc.data().userName,
-			"uid": doc.data().uid,
-			"talkSum": 0
-		})
+		if (doc.data().isActive) {
+
+			members.push({
+				"userName": doc.data().userName,
+				"uid": doc.data().uid,
+				"talkSum": 0
+			});
+		}
 	});
 
 	const querySnapshotTalkData = await dbRootRef.collection(talkDataCollection).orderBy("timestamp", "desc").limit(10).get()
@@ -255,4 +257,8 @@ async function getTalkDataFromFirebase() {
 	});
 
 	return members;
+}
+
+function updateTalkVisualizer() {
+
 }


### PR DESCRIPTION
発言量の全体によらず、固定長になりました。
`$('#voice-visualizer-group').first().innerWidth();` の長さは、Bootstrapで決まっててレスポンシブだから、画面外には飛び出ないはず！