### PR TITLE
fix(user left): talk bar updates when user left.

### DIFF
--- a/public/firebase/user-info.js
+++ b/public/firebase/user-info.js
@@ -1,5 +1,5 @@
 function addMyUserInfo() {
-	dbRootRef.collection(usersCollection).add({
+	dbRootRef.collection(usersCollection).doc(options.uid.toString()).set({
 		uid: options.uid,
 		userName: options.userName,
 		timeJoined: firebase.firestore.Timestamp.now(),
@@ -22,6 +22,12 @@ function listenUserInfo() {
 				$(`#player-wrapper-${uid}`).children('p').text(userName);
 			}
 
+			if (change.type === "modified") {
+				const isActive = change.doc.data().isActive;
+				if (!isActive) {
+					updateTalkBar();
+				}
+			}
 			/*
 			 * Todo: User name changalbe (such as "rename" funciton)
 			 */
@@ -33,4 +39,17 @@ function listenUserInfo() {
 			//}
 		})
 	})
+}
+
+function deactivateUser(uid) {
+	const docRef = dbRootRef.collection(usersCollection).doc(uid.toString());
+	docRef.get().then((doc) => {
+		if (doc.exists) {
+			docRef.update({
+				isActive: false
+			})
+		} else {
+			console.error(`Error: user ${uid} does not exists!`)
+		}
+	});
 }

--- a/public/index.js
+++ b/public/index.js
@@ -236,6 +236,9 @@ async function leave() {
 		$(".meeting-area").hide();
 		$("#leave").html(`<img src="icons/call_end_black_24dp.svg" alt="" class="material-icons">`)
 	}, 1000);
+
+	// Firestore
+	deactivateUser(options.uid);
 }
 
 /*

--- a/public/voice-visualizer.js
+++ b/public/voice-visualizer.js
@@ -53,8 +53,6 @@ function initTalkVisualizer() {
 	/*
 	 * Variables for talk amount observer
 	 */
-	const canvas = document.getElementById("talk-amount-visualizer");
-	const canvasCtx = canvas.getContext("2d");
 
 	const talkDataBufferLength = 1024;
 	const talkDataArray = new Array(talkDataBufferLength).fill(0);
@@ -146,37 +144,8 @@ function initTalkVisualizer() {
 				const talkDataAvg = talkDataArray.reduce((a, b) => a + b) / talkDataArray.length;
 				sendTalkDataToFirebase(talkDataAvg);
 
-				getTalkDataFromFirebase().then(result => {
-					let sum = 0;
-					for (let i = 0; i < result.length; i++) {
-						sum += result[i].talkSum;
-					}
-					canvas.setAttribute("width", $('#voice-visualizer-group').first().innerWidth());
-					const WIDTH = canvas.width;
-					const HEIGHT = canvas.height;
+				updateTalkBar();
 
-					canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
-
-					canvasCtx.fillStyle = '#0D0D0D';
-					canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
-
-					let deltaWidth = WIDTH / sum;
-
-					let x = 0;
-					for (let i = 0; i < result.length; i++) {
-						const width = deltaWidth * result[i].talkSum;
-						const height = HEIGHT / 5;
-
-						canvasCtx.fillStyle = colorPalette[i % colorPalette.length];
-						canvasCtx.fillRect(x, 0, width, height);
-
-						canvasCtx.font = '0.9em sans-serif';
-						canvasCtx.fillStyle = '#FFFFFF';
-						canvasCtx.fillText(result[i].userName, x, height + 20, width);
-
-						x += width;
-					}
-				});
 			} else {
 				talkDataSendTrigger.push(0);
 			}
@@ -259,6 +228,39 @@ async function getTalkDataFromFirebase() {
 	return members;
 }
 
-function updateTalkVisualizer() {
+function updateTalkBar() {
+	const canvas = document.getElementById("talk-amount-visualizer");
+	const canvasCtx = canvas.getContext("2d");
+	getTalkDataFromFirebase().then(result => {
+		let sum = 0;
+		for (let i = 0; i < result.length; i++) {
+			sum += result[i].talkSum;
+		}
+		canvas.setAttribute("width", $('#voice-visualizer-group').first().innerWidth());
+		const WIDTH = canvas.width;
+		const HEIGHT = canvas.height;
 
+		canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
+
+		canvasCtx.fillStyle = '#0D0D0D';
+		canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
+
+		let deltaWidth = WIDTH / sum;
+
+		let x = 0;
+		let width;
+		const height = HEIGHT / 5;
+		for (let i = 0; i < result.length; i++) {
+			width = deltaWidth * result[i].talkSum;
+
+			canvasCtx.fillStyle = colorPalette[i % colorPalette.length];
+			canvasCtx.fillRect(x, 0, width, height);
+
+			canvasCtx.font = '0.9em sans-serif';
+			canvasCtx.fillStyle = '#FFFFFF';
+			canvasCtx.fillText(result[i].userName, x, height + 20, width);
+
+			x += width;
+		}
+	});
 }

--- a/public/voice-visualizer.js
+++ b/public/voice-visualizer.js
@@ -197,32 +197,34 @@ function sendTalkDataToFirebase(value) {
 }
 
 async function getTalkDataFromFirebase() {
-	let members = [];
+	let users = [];
 	const querySnapshotUser = await dbRootRef.collection(usersCollection).get()
 	querySnapshotUser.forEach((doc) => {
-		members.push({
-			"userName": doc.data().userName,
-			"uid": doc.data().uid,
-			"talkSum": 0
-		})
+		if (doc.data().isActive) {
+			users.push({
+				"userName": doc.data().userName,
+				"uid": doc.data().uid,
+				"talkSum": 0
+			});
+		}
 	});
 
 	const querySnapshotTalkData = await dbRootRef.collection(talkDataCollection).orderBy("timestamp", "desc").limit(10).get()
 
 	querySnapshotTalkData.forEach((doc) => {
-		for (let i = 0; i < members.length; i++) {
-			if (doc.data().uid === members[i].uid) {
-				members[i].talkSum += doc.data().talkValue;
+		for (let i = 0; i < users.length; i++) {
+			if (doc.data().uid === users[i].uid) {
+				users[i].talkSum += doc.data().talkValue;
 			}
 		}
 	})
 
 	// reorder by talkSum
-	members.sort(function (a, b) {
+	users.sort(function (a, b) {
 		return b.talkSum - a.talkSum;
 	});
 
-	return members;
+	return users;
 }
 
 function updateTalkBar() {


### PR DESCRIPTION
1. Firestoreの`users` に、いま参加しているかどうか？（`isActive = true / false`）のFieldを追加した
2. `leave()`すると、`isActive = false` になる
3. `isActive = false`の変化をイベントリッスンして、それをトリガーとして描画更新
