### PR TITLE
fix(limit time extend): Now meeting time can be extended properly

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,30 +3,38 @@ const admin = require('firebase-admin');
 admin.initializeApp();
 
 exports.setTimeLimit = functions.firestore.document("/meetings/{meetingId}")
-    .onCreate((snapshot, context) => {
-        functions.logger.log(context.params.meetingId);
+	.onCreate((snapshot, context) => {
+		functions.logger.log(context.params.meetingId);
 
-        const date = new Date();
-        const duration = 40 * 60 * 1000; // Add 40 minutes to limit
-        const limit = new Date(date.getTime() + duration);
+		const nowMillis = admin.firestore.Timestamp.now().toMillis();
+		const durationMillis = 40 * 60 * 1000; // 40 minutes
+		const limit = nowMillis + durationMillis;
 
-        return snapshot.ref.set({
-            meetingStartedAt: admin.firestore.Timestamp.fromDate(date),
-            meetingLimitUntil: admin.firestore.Timestamp.fromDate(limit)
-        }, { merge: true });
-    });
+		return snapshot.ref.set({
+			meetingStartedAt: admin.firestore.Timestamp.fromMillis(nowMillis),
+			meetingLimitUntil: admin.firestore.Timestamp.fromMillis(limit)
+		}, { merge: true });
+	});
 
 exports.extendTimeLimit = functions.firestore
-    .document("/meetings/{meetingId}/extendLimit/{docId}")
-    .onWrite((change, context) => {
-        const meetingId = context.params.meetingId;
+	.document("/meetings/{meetingId}/extendLimit/{docId}")
+	.onWrite(async (change, context) => {
+		const meetingId = context.params.meetingId;
+		const docRef = admin.firestore().doc(`meetings/${meetingId}`);
+		const docSnapshot = await docRef.get()
 
-        const date = new Date();
-        const duration = 40 * 60 * 1000; // Add 40 minutes to limit
-        const limit = new Date(date.getTime() + duration);
+		if (docSnapshot.exists) {
 
-        admin.firestore().doc(`meetings/${meetingId}`).set({
-            lastTimeActive: admin.firestore.Timestamp.fromDate(date),
-            meetingLimitUntil: admin.firestore.Timestamp.fromDate(limit)
-        }, { merge: true });
-    });
+			const currentLimitMillis = docSnapshot.data().meetingLimitUntil.toMillis();
+			const durationMillis = 40 * 60 * 1000; // 40 minutes
+			const limit = currentLimitMillis + durationMillis;
+
+			admin.firestore().doc(`meetings/${meetingId}`).set({
+				lastTimeActive: admin.firestore.Timestamp.now(),
+				meetingLimitUntil: admin.firestore.Timestamp.fromMillis(limit)
+			}, { merge: true });
+		} else {
+			functions.logger.log("Error extending meeting limit. Check if document exists.")
+		}
+
+	});

--- a/src/modules/meeting-configuration.js
+++ b/src/modules/meeting-configuration.js
@@ -1,4 +1,5 @@
 import * as firestore from "@firebase/firestore";
+import * as stat_auth from "./stat_auth";
 import * as stat_firebase from "./stat_firebase";
 import * as _ from "..";
 
@@ -51,22 +52,21 @@ export async function initMeetingTimeLimit() {
 	// TODO: Currently anyone can extend meeting limit by clicking the link
 	// TODO: So, lets make this for premium account!
 	$(".limit-text a").on('click', async function () {
-		$(".limit-text a").css({
-			'color': 'aliceblue',
-			'cursor': 'not-allowed',
-			'opacity': '0.5',
-			'text-decoration': 'none'
-		});
+		$(".limit-text a").remove();
+
 		const collectionRef = firestore.collection(stat_firebase.dbRootRef, stat_firebase.extendLimitCollection);
 		await firestore.addDoc(collectionRef, {
 			timestamp: firestore.Timestamp.now(),
-			userName: stat_auth.user.userName,
+			displayNameStat: stat_auth.user.displayNameStat,
 			uid: stat_auth.user.uid
 		});
+
+		// Create event listner for show extended result instantly
+		const collectionRefExtend = firestore.collection(stat_firebase.dbRootRef, stat_firebase.extendLimitCollection);
+		const unsub = firestore.onSnapshot(collectionRefExtend, (doc) => {
+			update();
+		});
+
 	});
 
-	// Create event listner for show extended result instantly
-	const unsub = firestore.onSnapshot(stat_firebase.dbRootRef, (doc) => {
-		update();
-	})
 }


### PR DESCRIPTION
fix #174 
1. ミーティング時間をちゃんと延長できる（残り40分になる）
2. 一度延長したら、2度目はない（いちおう）
3. 延長は速攻でバーに反映される
4. バーの全体の長さはミーティング開始時間を起点としているので、残り40分でもバーの長さはMAXにはならない

最後のは、例えば「残り10分しかない！」で延長すると、全体が70分扱いになるので、残り40分→だいだい画面の半分の長さにバーが設定される