### PR TITLE
fix(user name): user name will not turn to uid after the user unpublish

### DIFF
--- a/src/modules/agora.js
+++ b/src/modules/agora.js
@@ -127,6 +127,9 @@ export async function unpublish() {
 	const unpublishedMessageElement = new bootstrap.Toast($('#unpublished-message'), toastOptions);
 	const publishedMessageElement = new bootstrap.Toast($('#published-message'), toastOptions);
 
+	// Firestore Update
+	stat_auth.adjustMyActiveStatus(published);
+
 	if (published === true) {
 		// Unpublish the user
 		await client.unpublish(Object.values(localTracks));
@@ -138,6 +141,7 @@ export async function unpublish() {
 		// Show toast message
 		unpublishedMessageElement.show();
 		publishedMessageElement.hide();
+
 	} else {
 		// Publish the user
 		await client.publish(Object.values(localTracks));
@@ -189,7 +193,7 @@ export async function leave() {
 	}, 1000);
 
 	// Firestore
-	stat_auth.deactivateMe();
+	stat_auth.adjustMyActiveStatus(false);
 }
 
 /*

--- a/src/modules/stat_auth.js
+++ b/src/modules/stat_auth.js
@@ -2,6 +2,7 @@ import * as auth from "firebase/auth";
 import * as bootstrap from "bootstrap";
 import * as firestore from "@firebase/firestore";
 import * as stat_firebase from "./stat_firebase";
+import * as voiceVisualizer from "./voice-visualizer";
 import * as _ from "..";
 
 export const user = {
@@ -120,16 +121,13 @@ export async function listenUserInfo() {
 					$(`#player-reaction-${uid}`).text(reaction);
 
 				} else {
+					// displayNameStat changed
+					const uid = change.doc.data().uid;
+					const displayNameStat = change.doc.data().displayNameStat;
+					$(`#player-wrapper-${uid}`).children('.player-name').text(displayNameStat);
 
-					const isActive = change.doc.data().isActive;
-					if (isActive) {
-						// displayNameStat changed
-						const uid = change.doc.data().uid;
-						const displayNameStat = change.doc.data().displayNameStat;
-						$(`#player-wrapper-${uid}`).children('.player-name').text(displayNameStat);
-					}
 					// If user deactivated, it will be automatically updated.
-					updateTalkBar();
+					voiceVisualizer.updateTalkBar();
 				}
 			}
 		});
@@ -151,12 +149,12 @@ export async function listenUserInfo() {
 	});
 }
 
-export async function deactivateMe() {
+export async function adjustMyActiveStatus(isActive) {
 	const docRef = firestore.doc(stat_firebase.dbRootRef, stat_firebase.usersCollection, user.uid);
 	const docSnap = await firestore.getDoc(docRef);
 	if (docSnap.exists()) {
 		firestore.updateDoc(docRef, {
-			isActive: false
+			isActive: isActive
 		})
 	} else {
 		console.error(`Error: user ${uid} does not exists!`)

--- a/src/modules/voice-visualizer.js
+++ b/src/modules/voice-visualizer.js
@@ -230,7 +230,7 @@ async function getTalkDataFromFirebase() {
 	return users;
 }
 
-function updateTalkBar() {
+export function updateTalkBar() {
 	const canvas = document.getElementById("talk-amount-visualizer");
 	const canvasCtx = canvas.getContext("2d");
 	getTalkDataFromFirebase().then(result => {


### PR DESCRIPTION
function `adjustMyActiveStatus(bool: isActive)` adjusts `isActive` field of Firestore so that the event
listener will know if the user unpublished/returned.

fix #173